### PR TITLE
Buffered io

### DIFF
--- a/decoderexif.go
+++ b/decoderexif.go
@@ -7,19 +7,19 @@ import (
 	"math/big"
 )
 
-func newDecoderExif(r io.Reader, callback HandleTagFunc) *decoderExif {
-	return &decoderExif{
+func newDecoderEXIF(r io.Reader, callback HandleTagFunc) *decoderEXIF {
+	return &decoderEXIF{
 		streamReader: newStreamReader(r),
 		handleTag:    callback,
 	}
 }
 
-type decoderExif struct {
+type decoderEXIF struct {
 	*streamReader
 	handleTag HandleTagFunc
 }
 
-func (e *decoderExif) convertValues(typ exifType, count, len int, r io.Reader) any {
+func (e *decoderEXIF) convertValues(typ exifType, count, len int, r io.Reader) any {
 	if count == 0 {
 		return nil
 	}
@@ -47,7 +47,7 @@ func (e *decoderExif) convertValues(typ exifType, count, len int, r io.Reader) a
 	return values
 }
 
-func (e *decoderExif) convertValue(typ exifType, r io.Reader) any {
+func (e *decoderEXIF) convertValue(typ exifType, r io.Reader) any {
 	switch typ {
 	case typeUnsignedByte, typeUndef:
 		return e.read1r(r)
@@ -69,7 +69,7 @@ func (e *decoderExif) convertValue(typ exifType, r io.Reader) any {
 	}
 }
 
-func (e *decoderExif) decode() (err error) {
+func (e *decoderEXIF) decode() (err error) {
 	byteOrderTag := e.read2()
 
 	switch byteOrderTag {
@@ -93,11 +93,11 @@ func (e *decoderExif) decode() (err error) {
 	e.skip(int64(firstOffset - 8))
 	e.readerOffset = e.pos() - 8
 
-	return e.decodeEXIFTags()
+	return e.decodeTags()
 
 }
 
-func (e *decoderExif) decodeEXIFTags() error {
+func (e *decoderEXIF) decodeTags() error {
 	if e.done() {
 		e.stop(nil)
 	}
@@ -105,7 +105,7 @@ func (e *decoderExif) decodeEXIFTags() error {
 	numTags := e.read2()
 
 	for i := 0; i < int(numTags); i++ {
-		if err := e.decodeEXIFTag(); err != nil {
+		if err := e.decodeTag(); err != nil {
 			return err
 		}
 	}
@@ -113,15 +113,15 @@ func (e *decoderExif) decodeEXIFTags() error {
 	return nil
 }
 
-func (e *decoderExif) decodeEXIFTagsAt(offset int) error {
+func (e *decoderEXIF) decodeTagsAT(offset int) error {
 	oldPos := e.pos()
 	defer func() {
 		e.seek(oldPos)
 	}()
 	e.seek(offset + e.readerOffset)
-	return e.decodeEXIFTags()
+	return e.decodeTags()
 }
 
-func (e *decoderExif) done() bool {
+func (e *decoderEXIF) done() bool {
 	return false // TODO1
 }

--- a/decoderitpc.go
+++ b/decoderitpc.go
@@ -1,0 +1,130 @@
+package imagemeta
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+func newDecoderIPTC(r io.Reader, callback HandleTagFunc) *decoderIPTC {
+	return &decoderIPTC{
+		streamReader: newStreamReader(r),
+		handleTag:    callback,
+	}
+}
+
+type decoderIPTC struct {
+	*streamReader
+	handleTag HandleTagFunc
+}
+
+func (e *decoderIPTC) decode() (err error) {
+	// Skip the IPTC header.
+	e.skip(14)
+
+	const iptcMetaDataBlockID = 0x0404
+
+	decodeBlock := func() error {
+		blockType := make([]byte, 4)
+		e.readFull(blockType)
+		if string(blockType) != "8BIM" {
+			return errStop
+		}
+
+		identifier := e.read2()
+		isMeta := identifier == iptcMetaDataBlockID
+
+		nameLength := e.read1()
+		if nameLength == 0 {
+			nameLength = 2
+		} else if nameLength%2 == 1 {
+			nameLength++
+		}
+
+		e.skip(int64(nameLength - 1))
+		dataSize := e.read4()
+
+		if !isMeta {
+			e.skip(int64(dataSize))
+			return nil
+		}
+
+		// TODO1 extended datasets.
+
+		if dataSize%2 != 0 {
+			defer func() {
+				// Skip padding byte.
+				e.skip(1)
+			}()
+		}
+
+		r := io.LimitReader(e.r, int64(dataSize))
+
+		for {
+			var marker uint8
+			if err := binary.Read(r, e.byteOrder, &marker); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+			if marker != 0x1C {
+				return errStop
+			}
+
+			var recordType, datasetNumber uint8
+			var recordSize uint16
+			if err := binary.Read(r, e.byteOrder, &recordType); err != nil {
+				return err
+			}
+			if err := binary.Read(r, e.byteOrder, &datasetNumber); err != nil {
+				return err
+			}
+			if err := binary.Read(r, e.byteOrder, &recordSize); err != nil {
+				return err
+			}
+
+			recordBytes := make([]byte, recordSize)
+			if err := binary.Read(r, e.byteOrder, recordBytes); err != nil {
+				return err
+			}
+
+			// TODO1 get an up to date field map.
+			// TODO1 handle unkonwn dataset numbers.
+			recordDef, ok := iptcFieldMap[datasetNumber]
+			if !ok {
+				fmt.Println("unknown datasetNumber", datasetNumber)
+				continue
+			}
+
+			var v any
+			switch recordDef.format {
+			case "string":
+				v = string(recordBytes)
+			case "B": // TODO1 check these
+				v = recordBytes
+			}
+
+			if err := e.handleTag(TagInfo{
+				Source: TagSourceIPTC,
+				Tag:    recordDef.name,
+				Value:  v,
+			}); err != nil {
+				return err
+			}
+
+		}
+	}
+
+	for {
+		if err := decodeBlock(); err != nil {
+			if err == errStop {
+				break
+			}
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/decoderwebp.go
+++ b/decoderwebp.go
@@ -104,7 +104,7 @@ func (e *decoderWebP) decode() (err error) {
 			if exifHandled {
 				continue
 			}
-			dec := newDecoderExif(chunkData, e.opts.HandleTag)
+			dec := newDecoderEXIF(chunkData, e.opts.HandleTag)
 
 			if err := dec.decode(); err != nil {
 				return err

--- a/imagemeta_test.go
+++ b/imagemeta_test.go
@@ -141,7 +141,7 @@ func BenchmarkDecode(b *testing.B) {
 	}
 
 	sourceSetEXIF := map[imagemeta.TagSource]bool{imagemeta.TagSourceEXIF: true}
-	sourceSetITPC := map[imagemeta.TagSource]bool{imagemeta.TagSourceIPTC: true}
+	sourceSetIPTC := map[imagemeta.TagSource]bool{imagemeta.TagSourceIPTC: true}
 	sourceSetAll := map[imagemeta.TagSource]bool{imagemeta.TagSourceEXIF: true, imagemeta.TagSourceIPTC: true}
 
 	runBenchmark := func(b *testing.B, name string, f func(r imagemeta.Reader) error) {
@@ -163,8 +163,8 @@ func BenchmarkDecode(b *testing.B) {
 		return err
 	})
 
-	runBenchmark(b, "bep/imagemeta/itpc", func(r imagemeta.Reader) error {
-		err := imagemeta.Decode(imagemeta.Options{R: r, ImageFormat: imagemeta.ImageFormatJPEG, HandleTag: handleTag, SourceSet: sourceSetITPC})
+	runBenchmark(b, "bep/imagemeta/iptc", func(r imagemeta.Reader) error {
+		err := imagemeta.Decode(imagemeta.Options{R: r, ImageFormat: imagemeta.ImageFormatJPEG, HandleTag: handleTag, SourceSet: sourceSetIPTC})
 		return err
 	})
 


### PR DESCRIPTION
```
name                          old time/op    new time/op    delta
Decode/bep/imagemeta/exif-10     209µs ± 2%      24µs ± 1%  -88.46%  (p=0.029 n=4+4)
Decode/bep/imagemeta/itpc-10    61.4µs ± 0%     8.9µs ± 1%  -85.51%  (p=0.029 n=4+4)
Decode/bep/imagemeta/all-10      269µs ± 3%      32µs ± 0%  -88.15%  (p=0.029 n=4+4)

name                          old alloc/op   new alloc/op   delta
Decode/bep/imagemeta/exif-10    7.57kB ± 0%    7.77kB ± 0%   +2.69%  (p=0.029 n=4+4)
Decode/bep/imagemeta/itpc-10    1.64kB ± 0%    1.83kB ± 0%  +11.45%  (p=0.029 n=4+4)
Decode/bep/imagemeta/all-10     9.08kB ± 0%    9.47kB ± 0%   +4.30%  (p=0.029 n=4+4)

name                          old allocs/op  new allocs/op  delta
Decode/bep/imagemeta/exif-10       832 ± 0%       837 ± 0%   +0.60%  (p=0.029 n=4+4)
Decode/bep/imagemeta/itpc-10       253 ± 0%       258 ± 0%   +1.98%  (p=0.029 n=4+4)
Decode/bep/imagemeta/all-10      1.08k ± 0%     1.09k ± 0%   +0.93%  (p=0.029 n=4+4)
```
