### PR TITLE
Add a ShouldHandleTag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ I welcome PRs with fixes, but please raise an issue first if you want to add new
 Extracting `EXIF` performs well, ref. the benhcmark below. Note that you can get a significant boost if you only need a subset of the fields (e.g. only the `Orientation`). The last line is with the library that [Hugo](https://github.com/gohugoio/hugo) used before it was replaced with this.
 
 ```bash
-BenchmarkDecodeExif/bep/imagemeta/exif/jpg/alltags-10              69238             17702 ns/op            4418 B/op        167 allocs/op
-BenchmarkDecodeExif/bep/imagemeta/exif/jpg/orientation-10         302263              3831 ns/op             650 B/op         19 allocs/op
-BenchmarkDecodeExif/rwcarlsen/goexif/exif/jpg/alltags-10           25791             47415 ns/op          175548 B/op        812 allocs/op
+BenchmarkDecodeExif/bep/imagemeta/exif/jpg/alltags-10              64575             16883 ns/op            4288 B/op        161 allocs/op
+BenchmarkDecodeExif/bep/imagemeta/exif/jpg/orientation-10         333732              3391 ns/op             409 B/op         10 allocs/op
+BenchmarkDecodeExif/rwcarlsen/goexif/exif/jpg/alltags-10           24782             46589 ns/op          175552 B/op        812 allocs/op
 ```
 
 Looking at some more extensive tests, testing different image formats and tag sources, we see that the current XMP implementation leaves a lot to be desired (you can provide your own XMP handler if you want). 
 
 ```bash
-BenchmarkDecode/bep/imagemeta/png/exif-10                  23444             50991 ns/op            4425 B/op        168 allocs/op
-BenchmarkDecode/bep/imagemeta/webp/all-10                   2980            399424 ns/op          177917 B/op       2436 allocs/op
-BenchmarkDecode/bep/imagemeta/webp/xmp-10                   3135            371387 ns/op          139866 B/op       2265 allocs/op
-BenchmarkDecode/bep/imagemeta/webp/exif-10                 37627             32057 ns/op           38187 B/op        177 allocs/op
-BenchmarkDecode/bep/imagemeta/jpg/exif-10                  68041             17813 ns/op            4420 B/op        167 allocs/op
-BenchmarkDecode/bep/imagemeta/jpg/iptc-10                 152806              7684 ns/op            1011 B/op         66 allocs/op
-BenchmarkDecode/bep/imagemeta/jpg/xmp-10                    3222            371182 ns/op          139860 B/op       2264 allocs/op
-BenchmarkDecode/bep/imagemeta/jpg/all-10                    2940            394144 ns/op          145267 B/op       2489 allocs/op
+BenchmarkDecode/bep/imagemeta/png/exif-10                  23732             49936 ns/op            4300 B/op        162 allocs/op
+BenchmarkDecode/bep/imagemeta/webp/all-10                   2970            391278 ns/op          177787 B/op       2430 allocs/op
+BenchmarkDecode/bep/imagemeta/webp/xmp-10                   3183            369343 ns/op          139862 B/op       2265 allocs/op
+BenchmarkDecode/bep/imagemeta/webp/exif-10                 38940             31184 ns/op           38075 B/op        171 allocs/op
+BenchmarkDecode/bep/imagemeta/jpg/exif-10                  68695             17670 ns/op            4289 B/op        161 allocs/op
+BenchmarkDecode/bep/imagemeta/jpg/iptc-10                 158425              7476 ns/op            1011 B/op         66 allocs/op
+BenchmarkDecode/bep/imagemeta/jpg/xmp-10                    3115            367200 ns/op          139861 B/op       2264 allocs/op
+BenchmarkDecode/bep/imagemeta/jpg/all-10                    3004            383872 ns/op          145157 B/op       2483 allocs/op
 ```
 
 ## When in doubt, Exiftools is right

--- a/imagedecoder_jpg.go
+++ b/imagedecoder_jpg.go
@@ -103,7 +103,7 @@ func (e *imageDecoderJPEG) handleEXIF(length int) error {
 		return err
 	}
 	defer r.Close()
-	exifr := newMetaDecoderEXIF(r, e.opts.HandleTag)
+	exifr := newMetaDecoderEXIF(r, e.opts)
 
 	header := exifr.read4()
 	if header != exifHeader {
@@ -124,6 +124,6 @@ func (e *imageDecoderJPEG) handleIPTC(length int) error {
 		return err
 	}
 	defer r.Close()
-	dec := newMetaDecoderIPTC(r, e.opts.HandleTag)
+	dec := newMetaDecoderIPTC(r, e.opts)
 	return dec.decode()
 }

--- a/imagedecoder_png.go
+++ b/imagedecoder_png.go
@@ -26,14 +26,12 @@ func (e *imageDecoderPNG) decode() error {
 					return err
 				}
 				defer r.Close()
-				exifr := newMetaDecoderEXIF(r, e.opts.HandleTag)
+				exifr := newMetaDecoderEXIF(r, e.opts)
 				return exifr.decode()
 			}()
-
 		}
 		e.skip(int64(chunkLength))
 		e.skip(4) // skip CRC
 
 	}
-
 }

--- a/imagedecoder_webp.go
+++ b/imagedecoder_webp.go
@@ -115,7 +115,7 @@ func (e *decoderWebP) decode() error {
 			}
 		case chunkID == fccEXIF && sourceSet.Has(EXIF):
 			r := io.LimitReader(e.r, int64(chunkLen))
-			dec := newMetaDecoderEXIF(r, e.opts.HandleTag)
+			dec := newMetaDecoderEXIF(r, e.opts)
 			if err := dec.decode(); err != nil {
 				return err
 			}

--- a/metadecoder_iptc.go
+++ b/metadecoder_iptc.go
@@ -27,10 +27,10 @@ var (
 	}
 )
 
-func newMetaDecoderIPTC(r io.Reader, callback HandleTagFunc) *metaDecoderIPTC {
+func newMetaDecoderIPTC(r io.Reader, opts Options) *metaDecoderIPTC {
 	return &metaDecoderIPTC{
 		streamReader: newStreamReader(r),
-		handleTag:    callback,
+		opts:         opts,
 	}
 }
 
@@ -46,7 +46,7 @@ type iptcField struct {
 
 type metaDecoderIPTC struct {
 	*streamReader
-	handleTag HandleTagFunc
+	opts Options
 }
 
 func (e *metaDecoderIPTC) decode() (err error) {
@@ -137,7 +137,7 @@ func (e *metaDecoderIPTC) decode() (err error) {
 			if recordDef.Repeatable {
 				stringSlices[recordDef] = append(stringSlices[recordDef], v.(string))
 			} else {
-				if err := e.handleTag(TagInfo{
+				if err := e.opts.HandleTag(TagInfo{
 					Source:    IPTC,
 					Tag:       recordDef.Name,
 					Namespace: recordDef.RecordName,
@@ -160,7 +160,7 @@ func (e *metaDecoderIPTC) decode() (err error) {
 
 	if len(stringSlices) > 0 {
 		for fieldDef, values := range stringSlices {
-			if err := e.handleTag(
+			if err := e.opts.HandleTag(
 				TagInfo{
 					Source:    IPTC,
 					Tag:       fieldDef.Name,

--- a/metadecoder_xmp.go
+++ b/metadecoder_xmp.go
@@ -54,6 +54,10 @@ func decodeXMP(r io.Reader, opts Options) error {
 			Value:     attr.Value,
 		}
 
+		if !opts.ShouldHandleTag(tagInfo) {
+			continue
+		}
+
 		if err := opts.HandleTag(tagInfo); err != nil {
 			return err
 		}


### PR DESCRIPTION
This speeds up processing if you're only interested in a sub set of the tags.

```
name                                              old time/op    new time/op    delta
DecodeExif/bep/imagemeta/exif/jpg/alltags-10        17.9µs ± 1%    17.3µs ± 2%   -3.25%  (p=0.029 n=4+4)
DecodeExif/bep/imagemeta/exif/jpg/orientation-10    3.90µs ± 1%    3.40µs ± 1%  -12.85%  (p=0.029 n=4+4)

name                                              old alloc/op   new alloc/op   delta
DecodeExif/bep/imagemeta/exif/jpg/alltags-10        4.42kB ± 0%    4.29kB ± 0%   -2.91%  (p=0.029 n=4+4)
DecodeExif/bep/imagemeta/exif/jpg/orientation-10      650B ± 0%      409B ± 0%  -37.07%  (p=0.029 n=4+4)

name                                              old allocs/op  new allocs/op  delta
DecodeExif/bep/imagemeta/exif/jpg/alltags-10           167 ± 0%       161 ± 0%   -3.59%  (p=0.029 n=4+4)
DecodeExif/bep/imagemeta/exif/jpg/orientation-10      19.0 ± 0%      10.0 ± 0%  -47.37%  (p=0.029 n=4+4)
```
