### PR TITLE
Bump GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install staticcheck
@@ -25,7 +25,7 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Fmt
         if: matrix.platform != 'windows-latest' # :(
         run: "diff <(gofmt -d .) <(printf '')"
@@ -39,6 +39,6 @@ jobs:
       - name: Test
         run: go test -race ./... -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ exiftool -ver
 12.76
 ```
 
-Debuggin tips:
+Debugging tips:
 
 ```bash
  exiftool testdata/goexif_samples/has-lens-info.jpg -htmldump > dump.html

--- a/imagemeta_test.go
+++ b/imagemeta_test.go
@@ -647,7 +647,7 @@ func readGoldenInfo(t testing.TB, filename string) goldenFileInfo {
 	for k, v := range m.IPTC {
 		if strings.Contains(k, "-") {
 			delete(m.IPTC, k)
-			// Exiftool has some weird hypenated keys, e.g. "By-line".
+			// Exiftool has some weird hyphenated keys, e.g. "By-line".
 			m.IPTC[strings.ReplaceAll(k, "-", "")] = v
 		}
 	}

--- a/io.go
+++ b/io.go
@@ -217,7 +217,7 @@ func (e *streamReader) skip(n int64) {
 }
 
 func (e *streamReader) stop(err error) {
-	// Alow one silent EOF.
+	// Allow one silent EOF.
 	// This allows the client to not having to check for EOF on every read.
 	if err == io.EOF && !e.isEOF {
 		e.isEOF = true

--- a/metadecoder_iptc.go
+++ b/metadecoder_iptc.go
@@ -16,7 +16,7 @@ var ipctTagsJSON []byte
 
 var (
 	iptcRecordFields = map[uint8]map[uint8]iptcField{}
-	iptcRerordNames  = map[uint8]string{
+	iptcRecordNames  = map[uint8]string{
 		1:   "IPTCEnvelope",
 		2:   "IPTCApplication",
 		3:   "IPTCNewsPhoto",
@@ -184,7 +184,7 @@ func getIptcRecordFieldDef(record, id uint8) (iptcField, bool) {
 }
 
 func getIptcRecordName(record uint8) string {
-	name, ok := iptcRerordNames[record]
+	name, ok := iptcRecordNames[record]
 	if !ok {
 		return fmt.Sprintf("IPTCUnknownRecord%d", record)
 	}


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/bep/imagemeta/actions/runs/9929421656).
It also fixes a few typos on the way.