### PR TITLE
Fix the bytes buffer slice allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,28 @@ I welcome PRs with fixes, but please raise an issue first if you want to add new
 Extracting `EXIF` performs well, ref. the benhcmark below. Note that you can get a significant boost if you only need a subset of the fields (e.g. only the `Orientation`). The last line is with the library that [Hugo](https://github.com/gohugoio/hugo) used before it was replaced with this.
 
 ```bash
-BenchmarkDecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/alltags-10                52466             21733 ns/op           12944 B/op        219 allocs/op
-BenchmarkDecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/orientation-10           253658              4861 ns/op            8548 B/op          9 allocs/op
-BenchmarkDecodeCompareWithGoexif/rwcarlsen/goexif/exif/jpg/alltags-10              23415             47897 ns/op          175549 B/op        812 allocs/op
+BenchmarkDecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/alltags-10                62474             19054 ns/op            4218 B/op        188 allocs/op
+BenchmarkDecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/orientation-10           309145              3723 ns/op             352 B/op          8 allocs/op
+BenchmarkDecodeCompareWithGoexif/rwcarlsen/goexif/exif/jpg/alltags-10              21987             50195 ns/op          175548 B/op        812 allocs/op
 ```
 
 Looking at some more extensive tests, testing different image formats and tag sources, we see that the current XMP implementation leaves a lot to be desired (you can provide your own XMP handler if you want). 
 
 ```bash
-BenchmarkDecode/png/exif-10                37803             31469 ns/op           12953 B/op        220 allocs/op
-BenchmarkDecode/png/all-10                  5628            203294 ns/op           57296 B/op        341 allocs/op
-BenchmarkDecode/webp/all-10                 3026            377070 ns/op          180064 B/op       2482 allocs/op
-BenchmarkDecode/webp/xmp-10                 3199            353637 ns/op          167224 B/op       2266 allocs/op
-BenchmarkDecode/webp/exif-10               45633             26524 ns/op           12977 B/op        222 allocs/op
-BenchmarkDecode/jpg/exif-10                56980             20971 ns/op           12946 B/op        219 allocs/op
-BenchmarkDecode/jpg/iptc-10               124027              9338 ns/op            8096 B/op         81 allocs/op
-BenchmarkDecode/jpg/iptc/category-10              193405              6391 ns/op            6987 B/op         16 allocs/op
-BenchmarkDecode/jpg/iptc/city-10                  170191              6757 ns/op            7083 B/op         18 allocs/op
-BenchmarkDecode/jpg/xmp-10                          3201            353794 ns/op          139864 B/op       2263 allocs/op
-BenchmarkDecode/jpg/all-10                          3032            381440 ns/op          160636 B/op       2555 allocs/op
-BenchmarkDecode/tiff/exif-10                        2096            554931 ns/op          223802 B/op        319 allocs/op
-BenchmarkDecode/tiff/iptc-10                       17203             69053 ns/op            2826 B/op        134 allocs/op
-BenchmarkDecode/tiff/all-10                         1280            916291 ns/op          393300 B/op       2707 allocs/op
+BenchmarkDecode/png/exif-10                39164             30783 ns/op            4231 B/op        189 allocs/op
+BenchmarkDecode/png/all-10                  5617            206111 ns/op           48611 B/op        310 allocs/op
+BenchmarkDecode/webp/all-10                 3069            379637 ns/op          144181 B/op       2450 allocs/op
+BenchmarkDecode/webp/xmp-10                 3291            359133 ns/op          139991 B/op       2265 allocs/op
+BenchmarkDecode/webp/exif-10               47028             25788 ns/op            4255 B/op        191 allocs/op
+BenchmarkDecode/jpg/exif-10                58701             20216 ns/op            4223 B/op        188 allocs/op
+BenchmarkDecode/jpg/iptc-10               135777              8725 ns/op            1562 B/op         80 allocs/op
+BenchmarkDecode/jpg/iptc/category-10      215674              5393 ns/op             456 B/op         15 allocs/op
+BenchmarkDecode/jpg/iptc/city-10          192067              6201 ns/op             553 B/op         17 allocs/op
+BenchmarkDecode/jpg/xmp-10                  3244            359436 ns/op          139861 B/op       2263 allocs/op
+BenchmarkDecode/jpg/all-10                  2874            389489 ns/op          145700 B/op       2523 allocs/op
+BenchmarkDecode/tiff/exif-10                2065            566786 ns/op          214089 B/op        282 allocs/op
+BenchmarkDecode/tiff/iptc-10               16761             71003 ns/op            2603 B/op        133 allocs/op
+BenchmarkDecode/tiff/all-10                 1267            933321 ns/op          356878 B/op       2668 allocs/op
 ```
 
 ## When in doubt, Exiftool is right

--- a/io.go
+++ b/io.go
@@ -24,7 +24,7 @@ var bytesAndReaderPool = &sync.Pool{
 
 func getBytesAndReader(length int) *bytesAndReader {
 	b := bytesAndReaderPool.Get().(*bytesAndReader)
-	if length > len(b.b) {
+	if length > cap(b.b) {
 		b.b = make([]byte, length)
 	}
 	b.b = b.b[:length]
@@ -121,7 +121,7 @@ func (e *streamReader) bufferedReader(length int64) (readerCloser, error) {
 }
 
 func (e *streamReader) allocateBuf(length int) {
-	if length > len(e.buf) {
+	if length > cap(e.buf) {
 		e.buf = make([]byte, length)
 	}
 }


### PR DESCRIPTION
The correct is of course to use `cap` and not `length`...

```bash
name                                                            old time/op    new time/op    delta
Decode/png/exif-10                                                32.1µs ± 2%    30.4µs ± 2%   -5.27%  (p=0.029 n=4+4)
Decode/png/all-10                                                  209µs ± 7%     202µs ± 0%   -3.52%  (p=0.029 n=4+4)
Decode/webp/all-10                                                 375µs ± 1%     372µs ± 0%   -0.93%  (p=0.029 n=4+4)
Decode/webp/xmp-10                                                 354µs ± 0%     353µs ± 0%     ~     (p=0.343 n=4+4)
Decode/webp/exif-10                                               26.4µs ± 1%    25.3µs ± 1%   -4.19%  (p=0.029 n=4+4)
Decode/jpg/exif-10                                                21.0µs ± 0%    19.8µs ± 0%   -5.77%  (p=0.029 n=4+4)
Decode/jpg/iptc-10                                                9.25µs ± 0%    8.57µs ± 0%   -7.36%  (p=0.029 n=4+4)
Decode/jpg/iptc/category-10                                       5.90µs ± 1%    5.30µs ± 1%  -10.15%  (p=0.029 n=4+4)
Decode/jpg/iptc/city-10                                           6.77µs ± 0%    6.08µs ± 0%  -10.13%  (p=0.029 n=4+4)
Decode/jpg/xmp-10                                                  355µs ± 0%     354µs ± 1%     ~     (p=0.886 n=4+4)
Decode/jpg/all-10                                                  380µs ± 0%     380µs ± 1%     ~     (p=0.886 n=4+4)
Decode/tiff/exif-10                                                557µs ± 0%     555µs ± 0%     ~     (p=0.200 n=4+4)
Decode/tiff/iptc-10                                               69.2µs ± 0%    69.4µs ± 0%     ~     (p=0.343 n=4+4)
Decode/tiff/all-10                                                 918µs ± 0%     917µs ± 1%     ~     (p=0.686 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/alltags-10        21.8µs ± 0%    20.7µs ± 0%   -5.11%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/orientation-10    4.44µs ± 1%    3.71µs ± 1%  -16.39%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/rwcarlsen/goexif/exif/jpg/alltags-10      47.3µs ± 0%    47.7µs ± 0%   +0.94%  (p=0.029 n=4+4)

name                                                            old alloc/op   new alloc/op   delta
Decode/png/exif-10                                                13.0kB ± 0%     4.2kB ± 0%  -67.35%  (p=0.029 n=4+4)
Decode/png/all-10                                                 57.3kB ± 0%    48.6kB ± 0%  -15.18%  (p=0.029 n=4+4)
Decode/webp/all-10                                                 180kB ± 0%     144kB ± 0%  -19.96%  (p=0.029 n=4+4)
Decode/webp/xmp-10                                                 167kB ± 0%     140kB ± 0%  -16.29%  (p=0.029 n=4+4)
Decode/webp/exif-10                                               13.0kB ± 0%     4.3kB ± 0%  -67.22%  (p=0.029 n=4+4)
Decode/jpg/exif-10                                                12.9kB ± 0%     4.2kB ± 0%  -67.39%  (p=0.029 n=4+4)
Decode/jpg/iptc-10                                                8.10kB ± 0%    1.56kB ± 0%  -80.70%  (p=0.029 n=4+4)
Decode/jpg/iptc/category-10                                       6.99kB ± 0%    0.46kB ± 0%  -93.47%  (p=0.029 n=4+4)
Decode/jpg/iptc/city-10                                           7.08kB ± 0%    0.55kB ± 0%  -92.20%  (p=0.029 n=4+4)
Decode/jpg/xmp-10                                                  140kB ± 0%     140kB ± 0%     ~     (p=0.571 n=4+4)
Decode/jpg/all-10                                                  161kB ± 0%     146kB ± 0%   -9.35%  (p=0.029 n=4+4)
Decode/tiff/exif-10                                                224kB ± 0%     214kB ± 0%   -4.36%  (p=0.029 n=4+4)
Decode/tiff/iptc-10                                               2.83kB ± 0%    2.60kB ± 0%   -7.93%  (p=0.029 n=4+4)
Decode/tiff/all-10                                                 393kB ± 0%     357kB ± 0%   -9.21%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/alltags-10        12.9kB ± 0%     4.2kB ± 0%  -67.36%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/orientation-10    8.55kB ± 0%    0.35kB ± 0%  -95.88%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/rwcarlsen/goexif/exif/jpg/alltags-10       176kB ± 0%     176kB ± 0%     ~     (p=0.743 n=4+4)

name                                                            old allocs/op  new allocs/op  delta
Decode/png/exif-10                                                   220 ± 0%       189 ± 0%  -14.09%  (p=0.029 n=4+4)
Decode/png/all-10                                                    341 ± 0%       310 ± 0%   -9.09%  (p=0.029 n=4+4)
Decode/webp/all-10                                                 2.48k ± 0%     2.45k ± 0%   -1.29%  (p=0.029 n=4+4)
Decode/webp/xmp-10                                                 2.27k ± 0%     2.27k ± 0%   -0.04%  (p=0.029 n=4+4)
Decode/webp/exif-10                                                  222 ± 0%       191 ± 0%  -13.96%  (p=0.029 n=4+4)
Decode/jpg/exif-10                                                   219 ± 0%       188 ± 0%  -14.16%  (p=0.029 n=4+4)
Decode/jpg/iptc-10                                                  81.0 ± 0%      80.0 ± 0%   -1.23%  (p=0.029 n=4+4)
Decode/jpg/iptc/category-10                                         16.0 ± 0%      15.0 ± 0%   -6.25%  (p=0.029 n=4+4)
Decode/jpg/iptc/city-10                                             18.0 ± 0%      17.0 ± 0%   -5.56%  (p=0.029 n=4+4)
Decode/jpg/xmp-10                                                  2.26k ± 0%     2.26k ± 0%     ~     (all equal)
Decode/jpg/all-10                                                  2.56k ± 0%     2.52k ± 0%   -1.25%  (p=0.029 n=4+4)
Decode/tiff/exif-10                                                  319 ± 0%       282 ± 0%  -11.60%  (p=0.029 n=4+4)
Decode/tiff/iptc-10                                                  134 ± 0%       133 ± 0%   -0.75%  (p=0.029 n=4+4)
Decode/tiff/all-10                                                 2.71k ± 0%     2.67k ± 0%   -1.44%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/alltags-10           219 ± 0%       188 ± 0%  -14.16%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/bep/imagemeta/exif/jpeg/orientation-10      9.00 ± 0%      8.00 ± 0%  -11.11%  (p=0.029 n=4+4)
DecodeCompareWithGoexif/rwcarlsen/goexif/exif/jpg/alltags-10         812 ± 0%       812 ± 0%     ~     (all equal)
```
