### PR TITLE
Fix test for corrupt files

### DIFF
--- a/imagemeta_test.go
+++ b/imagemeta_test.go
@@ -152,8 +152,9 @@ func TestDecodeTIFF(t *testing.T) {
 func TestDecodeCorrupt(t *testing.T) {
 	c := qt.New(t)
 
-	files, err := filepath.Glob(filepath.Join("testdata", "corrupt", "*.*"))
+	files, err := filepath.Glob(filepath.Join("testdata", "images", "corrupt", "*.*"))
 	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 3)
 
 	for _, file := range files {
 		img, err := os.Open(file)
@@ -163,7 +164,11 @@ func TestDecodeCorrupt(t *testing.T) {
 			return nil
 		}
 		err = imagemeta.Decode(imagemeta.Options{R: img, ImageFormat: format, HandleTag: handleTag, Warnf: panicWarnf})
-		c.Assert(imagemeta.IsInvalidFormat(err), qt.IsTrue, qt.Commentf("file: %s", file))
+
+		if !imagemeta.IsInvalidFormat(err) {
+			c.Assert(err, qt.ErrorMatches, "UserComment: expected \\[\\]uint8, got string", qt.Commentf("file: %s", file))
+		}
+
 		img.Close()
 	}
 }


### PR DESCRIPTION
I noticed that the test for the corrupt image samples does not actually process any files (possibly since refactoring the testdata structure in 783baa56dc39082459a0196413f161ff7faa14a8?).

After fixing the path the tests were still failing. It appears that due to changes in the library only one of the corrupt images now returns an invalid format error, and the other two produce a type mismatch error on decoding the `UserComment` field.