### PR TITLE
Drop warning for UserComment type assertion

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -294,7 +294,7 @@ func (vc) convertStringToInt(ctx valueConverterContext, v any) any {
 
 func (c vc) convertUserComment(ctx valueConverterContext, v any) any {
 	// UserComment tag is identified based on an ID code in a fixed 8-byte area at the start of the tag data area.
-	b, ok := typeAssert[[]byte](ctx, v)
+	b, ok := typeAssertNoWarn[[]byte](ctx, v)
 	if !ok {
 		// Handle plain string user comment (which is against spec; but commonly done)
 		// Exiftool prints a warning but returns the string as-is.
@@ -498,4 +498,9 @@ func typeAssert[T any](ctx valueConverterContext, v any) (T, bool) {
 		return vv, false
 	}
 	return vv, true
+}
+
+func typeAssertNoWarn[T any](ctx valueConverterContext, v any) (T, bool) {
+	vv, ok := v.(T)
+	return vv, ok
 }

--- a/imagemeta_test.go
+++ b/imagemeta_test.go
@@ -188,9 +188,7 @@ func TestDecodeUserCommentWithInvalidEncoding(t *testing.T) {
 		return nil
 	}
 
-	var warning error
 	warnf := func(format string, args ...any) {
-		warning = fmt.Errorf(format, args...)
 	}
 
 	err = imagemeta.Decode(imagemeta.Options{R: img, ImageFormat: imagemeta.JPEG, HandleTag: handleTag, Sources: imagemeta.EXIF, Warnf: warnf})
@@ -199,9 +197,6 @@ func TestDecodeUserCommentWithInvalidEncoding(t *testing.T) {
 	// Expect user comment to be decoded
 	c.Assert(userComment, qt.IsNotNil)
 	c.Assert(userComment, eq, "UserComment")
-
-	// But with a warning about incorrect type
-	c.Assert(warning, qt.ErrorMatches, "UserComment: expected \\[\\]uint8, got string")
 }
 
 func TestDecodeCustomXMPHandler(t *testing.T) {


### PR DESCRIPTION
It's too common to warn about.
