### PR TITLE
Fix GPSTimeStamp for fractional seconds stored as low-denominator rationals

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -346,16 +346,15 @@ func (c vc) convertToTimestampString(ctx valueConverterContext, v any) any {
 		if len(vv) != 3 {
 			return time.Time{}
 		}
-		for i, v := range vv {
-			vv[i] = c.ratNum(v)
+		h := c.ratNum(vv[0])
+		m := c.ratNum(vv[1])
+		// Seconds may be fractional (e.g. 362/10 = 36.2 or 4279/100 = 42.79).
+		secs := toFloat64(vv[2])
+		secsStr := strconv.FormatFloat(secs, 'f', -1, 64)
+		if secs < 10 {
+			secsStr = "0" + secsStr
 		}
-		s := fmt.Sprintf("%02d:%02d:%02d", vv...)
-
-		if len(s) == 10 {
-			// 13:03:4279 => 13:03:42.79
-			s = s[:8] + "." + s[8:]
-		}
-		return s
+		return fmt.Sprintf("%02d:%02d:%s", h, m, secsStr)
 	case string:
 		// 17,00000,8,00000,29,0000
 		parts := strings.Split(vv, ",")


### PR DESCRIPTION
The `convertToTimestampString` converter in `helpers.go` used `ratNum()` (numerator
only) for all three components, then formatted with `%02d`. It had a follow-up hack
that detected 10-character results and inserted a decimal point, e.g.:

    4279/100 → numerator 4279 → "13:03:4279" (10 chars) → "13:03:42.79"  ✓

This only works when the seconds numerator happens to be exactly 4 digits. A rational
like 181/5 (= 36.2 seconds) has a 3-digit numerator and falls through:

    181/5 → numerator 181 → "22:22:181" (9 chars) → no decimal inserted  ✗

Fix: compute the seconds value properly using `toFloat64()` (already used elsewhere
for GPS coordinate conversion) and format with `strconv.FormatFloat(secs, 'f', -1, 64)`.
Integer seconds (e.g. 47/1) still produce "47" with no trailing decimal; fractional
seconds (e.g. 181/5) produce "36.2".

The existing `goexif/has-lens-info.jpg` golden test (seconds = 4279/100 = 42.79)
continues to pass as before.

This bug was discovered while adding HEIF support and testing against an iPhone 15 Pro
photo whose GPS log records seconds as 181/5.