### PR TITLE
png: Bound allocations in the zTXt Raw profile type iptc path

### DIFF
--- a/imagedecoder_png.go
+++ b/imagedecoder_png.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -90,6 +91,9 @@ func (e *imageDecoderPNG) decode() error {
 					if err != nil {
 						return newInvalidFormatError(fmt.Errorf("decompressing zTXt: %w", err))
 					}
+					if int64(len(data)) < profileNameLength {
+						return newInvalidFormatErrorf("zTXt data too short: %d", len(data))
+					}
 					data = data[profileNameLength:] // Skip the header bytes.
 					data = bytes.ReplaceAll(data, []byte("\n"), []byte(""))
 					d := make([]byte, hex.DecodedLen(len(data)))
@@ -120,6 +124,9 @@ func (e *imageDecoderPNG) decode() error {
 }
 
 func decompressZTXt(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("no zTXt data")
+	}
 	// The first byte indicates the compression method, for which only deflate is currently defined (method zero).
 	compressionMethod := data[0]
 	if compressionMethod != 0 {
@@ -131,6 +138,14 @@ func decompressZTXt(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	defer z.Close()
-	p, err := io.ReadAll(z)
-	return p, err
+
+	// Bound the inflated size; a small zlib stream can otherwise expand to gigabytes.
+	p, err := io.ReadAll(io.LimitReader(z, maxBufSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(p) > maxBufSize {
+		return nil, fmt.Errorf("uncompressed zTXt size exceeds max %d", maxBufSize)
+	}
+	return p, nil
 }

--- a/io.go
+++ b/io.go
@@ -289,6 +289,12 @@ func (e *streamReader) readNFromRIntoBuf(n int, r io.Reader) {
 }
 
 func (e *streamReader) readNFromRIntoBufE(n int, r io.Reader) error {
+	if n < 0 {
+		return newInvalidFormatErrorf("negative length %d", n)
+	}
+	if n > maxBufSize {
+		return newInvalidFormatErrorf("length %d exceeds max %d", n, maxBufSize)
+	}
 	e.allocateBuf(n)
 	n2, err := io.ReadFull(r, e.buf[:n])
 	if err != nil {

--- a/metadecoder_iptc.go
+++ b/metadecoder_iptc.go
@@ -405,7 +405,7 @@ func resolveCodedCharacterSet(b []byte) string {
 		return characterSetISO88591
 	}
 
-	if len(b) > 3 && b[0] == esc && (b[1] == dot || b[2] == dot || b[3] == dot) && b[4] == latinCapitalA {
+	if len(b) > 4 && b[0] == esc && (b[1] == dot || b[2] == dot || b[3] == dot) && b[4] == latinCapitalA {
 		return characterSetISO88591
 	}
 

--- a/security_test.go
+++ b/security_test.go
@@ -1,0 +1,123 @@
+// Copyright 2024 Bjørn Erik Pedersen
+// SPDX-License-Identifier: MIT
+
+package imagemeta
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// pngWithRawProfileIPTC builds a minimal PNG with a single zTXt chunk carrying the
+// "Raw profile type iptc" keyword. declaredDataLen goes into the chunk length, so it
+// can be made to disagree with the payload actually delivered.
+func pngWithRawProfileIPTC(declaredDataLen int, payload []byte) []byte {
+	keyword := append([]byte("Raw profile type iptc"), 0)
+	var buf bytes.Buffer
+	buf.Write([]byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a})
+	binary.Write(&buf, binary.BigEndian, uint32(len(keyword)+declaredDataLen))
+	buf.WriteString("zTXt")
+	buf.Write(keyword)
+	buf.Write(payload)
+	buf.Write([]byte{0, 0, 0, 0}) // CRC
+	return buf.Bytes()
+}
+
+// zTXtPayload returns a deflate compression method byte followed by a zlib stream
+// that inflates to size bytes of hex digits.
+func zTXtPayload(size int) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(0) // Compression method: deflate.
+	w := zlib.NewWriter(&buf)
+	w.Write(bytes.Repeat([]byte("41"), size/2))
+	w.Close()
+	return buf.Bytes()
+}
+
+func decodePNGIPTC(b []byte) error {
+	_, err := Decode(Options{
+		R:           bytes.NewReader(b),
+		ImageFormat: PNG,
+		Sources:     IPTC,
+	})
+	return err
+}
+
+// A length read off the wire must never reach make. This is the bound the eXIf path
+// has always had via bufferedReader; it lives in the shared read primitive so every
+// size-bearing read inherits it.
+func TestReadNBounds(t *testing.T) {
+	c := qt.New(t)
+
+	read := func(n int) error {
+		e := newStreamReader(bytes.NewReader(make([]byte, 8)), binary.BigEndian)
+		return e.readNFromRIntoBufE(n, e.r)
+	}
+
+	c.Assert(read(maxBufSize+1), qt.ErrorMatches, ".*exceeds max.*")
+	c.Assert(read(-1), qt.ErrorMatches, ".*negative length.*")
+	c.Assert(read(4), qt.IsNil)
+}
+
+// A small zlib stream must not be allowed to inflate without bound.
+func TestDecompressZTXtBounds(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := decompressZTXt(zTXtPayload(maxBufSize * 4))
+	c.Assert(err, qt.ErrorMatches, ".*uncompressed zTXt size exceeds max.*")
+
+	_, err = decompressZTXt(nil)
+	c.Assert(err, qt.ErrorMatches, ".*no zTXt data.*")
+
+	b, err := decompressZTXt(zTXtPayload(64))
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(b), qt.Equals, 64)
+}
+
+// End to end: a crafted PNG must not be able to drive an allocation from its declared
+// chunk length, nor inflate without bound. Both are memory exhaustion, which recover
+// cannot catch.
+func TestDecodePNGZTXtRawProfileIPTC(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("inflated size beyond max", func(c *qt.C) {
+		payload := zTXtPayload(maxBufSize * 4)
+		c.Assert(len(payload) < 600*1024, qt.IsTrue, qt.Commentf("payload is %d bytes", len(payload)))
+		c.Assert(decodePNGIPTC(pngWithRawProfileIPTC(len(payload), payload)), qt.ErrorMatches, ".*uncompressed zTXt size exceeds max.*")
+	})
+
+	c.Run("inflated size shorter than keyword", func(c *qt.C) {
+		payload := zTXtPayload(4)
+		c.Assert(decodePNGIPTC(pngWithRawProfileIPTC(len(payload), payload)), qt.ErrorMatches, ".*zTXt data too short.*")
+	})
+
+	c.Run("no data", func(c *qt.C) {
+		c.Assert(decodePNGIPTC(pngWithRawProfileIPTC(0, nil)), qt.ErrorMatches, ".*no zTXt data.*")
+	})
+
+	// 42 bytes on disk claiming 256 MB of zTXt data. The declared length is rejected
+	// before it reaches make, so this returns without consuming the claimed memory.
+	c.Run("declared length beyond max", func(c *qt.C) {
+		png := pngWithRawProfileIPTC(256<<20, nil)
+		c.Assert(len(png) < 64, qt.IsTrue)
+		c.Assert(decodePNGIPTC(png), qt.IsNil)
+	})
+}
+
+// resolveCodedCharacterSet indexes b[4], so it must require 5 bytes, not 4.
+func TestResolveCodedCharacterSetShortInput(t *testing.T) {
+	c := qt.New(t)
+
+	for i := range 6 {
+		b := bytes.Repeat([]byte{0x1b}, i)
+		c.Assert(func() { resolveCodedCharacterSet(b) }, qt.Not(qt.PanicMatches), ".*")
+	}
+
+	c.Assert(resolveCodedCharacterSet([]byte{0x1b, 0x2e, 0x2e, 0x2e}), qt.Equals, "")
+	c.Assert(resolveCodedCharacterSet([]byte{0x1b, 0x2e, 0x2e, 0x2e, 0x41}), qt.Equals, characterSetISO88591)
+	c.Assert(resolveCodedCharacterSet([]byte{0x1b, 0x25, 0x47}), qt.Equals, characterSetUTF8)
+}


### PR DESCRIPTION
The chunk length drove a make via readBytesVolatile, bypassing the
maxBufSize guard that only covered bufferedReader, and the zTXt stream
was inflated with an unbounded io.ReadAll. A 42 byte PNG allocated
256 MB and a 127 KB one inflated to 460 MB.

Move the bound into readNFromRIntoBufE so every size-bearing read
inherits it, cap the inflated output, and guard the empty-data and
short-data indexing in decompressZTXt.

Also fix an index out of range in resolveCodedCharacterSet, which read
b[4] after only checking len(b) > 3.

Reported by Arpit Jain (arpitjain099).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
